### PR TITLE
agrege limite en clave de rastreo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-## STP client python3 client library 
+## STP client python3 client library
 
 [![Build Status](https://travis-ci.com/cuenca-mx/stpmex-python.svg?branch=master)](https://travis-ci.com/cuenca-mx/stpmex-python)
 
-Cliente para el servicio SOAP de STP 
+
+Cliente para el servicio SOAP de STP
 
 Demo wsdl: https://demo.stpmex.com:7024/speidemo/webservices/SpeiActualizaServices?wsdl
 

--- a/stpmex/ordenes.py
+++ b/stpmex/ordenes.py
@@ -58,7 +58,8 @@ VALIDATIONS = dict(
         maxLength=39
     ),
     claveRastreo=dict(
-        required=True
+        required=True,
+        maxLength=30
     ),
     conceptoPago=dict(
         required=True

--- a/tests.py
+++ b/tests.py
@@ -130,3 +130,9 @@ def test_valid_stp_bank():
     stp_bank = 40002
     spei_code = stp_to_spei_bank_code(stp_bank)
     assert spei_code == BankCode.BANAMEX.value
+
+def test_max_length_clave(initialize_stpmex, get_order):
+    order = get_order
+    order.claveRastreo = '1234567891234567891234567891234'
+    with pytest.raises(ValueError):
+        order.registra()


### PR DESCRIPTION
agrege limite de longitud en las validaciones de la clave de rastreo  en ordenes.py y el test de la misma en test.py issue #12  