### PR TITLE
Fix optional fields validation

### DIFF
--- a/stpmex/orden.py
+++ b/stpmex/orden.py
@@ -5,10 +5,11 @@ from dataclasses import field
 from typing import Optional, Type
 
 import clabe
-from pydantic import PositiveFloat, conint, constr, validator
+from pydantic import PositiveFloat, conint, constr
 from pydantic.dataclasses import dataclass
 
 from .types import Prioridad, TipoCuenta
+from .validation import validator
 
 STP_BANK_CODE = '90646'
 

--- a/stpmex/validation.py
+++ b/stpmex/validation.py
@@ -1,0 +1,23 @@
+from inspect import signature
+
+from pydantic import validator as pydantic_validator
+
+
+def validator(*args, **kwargs):
+    def decorator(func):
+        def wrapped_validator(cls, v, values, field, config):
+            if field.allow_none and v is None:
+                return v
+
+            func_args = list(signature(func).parameters.keys())
+            v_kwargs = {'values': values, 'field': field, 'config': config}
+            call_kwargs = {k: v_kwargs[k] for k in func_args[2:]}
+
+            return func(cls, v, **call_kwargs)
+
+        kwargs['allow_reuse'] = True
+        f_cls = pydantic_validator(*args, **kwargs)(wrapped_validator)
+
+        return f_cls
+
+    return decorator


### PR DESCRIPTION
Pydantic applies custom validators to optional fields even when they’re `None`. 12 tests are currently failing because of this.

This PR adds a custom `@validator` decorator as a drop-in replacement for pydantic’s one that skips running validation on empty optional fields. When they’re not, it calls pydantic’s validator.