### PR TITLE
Adding StrictPositiveFloat in Ordenes

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,7 +2,7 @@ black==20.8b1
 isort==5.5.*
 flake8==3.8.*
 mypy==0.782
-pytest==6.0.*
+pytest==6.1.*
 pytest-vcr==1.0.*
 pytest-cov==2.10.*
 requests-mock==1.8.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 cryptography==3.1
-cuenca-validations==0.5.5
+cuenca-validations==0.5.9
 requests==2.24.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-cryptography==3.1
+cryptography==3.1.1
 cuenca-validations==0.5.9
 requests==2.24.0

--- a/stpmex/resources/ordenes.py
+++ b/stpmex/resources/ordenes.py
@@ -6,8 +6,8 @@ from typing import Any, ClassVar, Dict, List, Optional, Union
 
 import clabe
 from clabe.types import Clabe
-from cuenca_validations.types import PaymentCardNumber
-from pydantic import PositiveFloat, conint, constr, validator
+from cuenca_validations.types import PaymentCardNumber, StrictPositiveFloat
+from pydantic import conint, constr, validator
 from pydantic.dataclasses import dataclass
 
 from ..auth import ORDEN_FIELDNAMES
@@ -37,7 +37,7 @@ class Orden(Resource):
     _endpoint: ClassVar[str] = '/ordenPago'
     _firma_fieldnames: ClassVar[List[str]] = ORDEN_FIELDNAMES
 
-    monto: PositiveFloat
+    monto: StrictPositiveFloat
     conceptoPago: truncated_str(39)
 
     cuentaBeneficiario: Union[Clabe, PaymentCardNumber, MxPhoneNumber]
@@ -69,9 +69,6 @@ class Orden(Resource):
     id: Optional[int] = None
 
     def __post_init__(self):
-        # Test before Pydantic coerces it to a float
-        if not isinstance(self.monto, float):
-            raise ValueError('monto must be a float')
         cb = self.cuentaBeneficiario
         self.tipoCuentaBeneficiario = self.get_tipo_cuenta(cb)
 

--- a/tests/resources/test_ordenes.py
+++ b/tests/resources/test_ordenes.py
@@ -3,6 +3,7 @@ import time
 from typing import Any, Dict
 
 import pytest
+from pydantic.error_wrappers import ValidationError
 
 from stpmex import Client
 from stpmex.exc import NoOrdenesEncontradas
@@ -28,6 +29,22 @@ def test_registra_orden(client: Client, orden_dict: Dict[str, Any]):
 )
 def test_tipoCuentaBeneficiario(cuenta: str, tipo: TipoCuenta):
     assert Orden.get_tipo_cuenta(cuenta) == tipo
+
+
+@pytest.mark.parametrize(
+    'monto, msg',
+    [
+        (-1.3, 'ensure this value is greater than 0'),
+        (1, 'value is not a valid float'),
+    ],
+)
+def test_strict_pos_float(monto, msg: str, orden_dict: Dict[str, Any]):
+    orden_dict['claveRastreo'] = f'CR{int(time.time())}'
+    orden_dict['monto'] = monto
+
+    with pytest.raises(ValidationError) as exc:
+        Orden(**orden_dict)
+    assert msg in str(exc.value)
 
 
 @pytest.mark.vcr


### PR DESCRIPTION
- Changing the way Orden object validates monto, and instead of checking for float typing, and then for PositiveFloat, it uses StrictPositiveFloat typing from cuenca_validations that does the same.
- Bumping requirements versions

closes #121 